### PR TITLE
Update abstract.php

### DIFF
--- a/code/libraries/koowa/libraries/user/session/abstract.php
+++ b/code/libraries/koowa/libraries/user/session/abstract.php
@@ -320,8 +320,11 @@ class KUserSessionAbstract extends KObject implements KUserSessionInterface
                 $identifier = $this->getIdentifier()->toArray();
                 $identifier['path'] = array('session', 'handler');
                 $identifier['name'] = $handler;
+                // reset the handler
+                $handler = $identifier;
             }
-            else $identifier = $this->getIdentifier($handler);
+            
+            $identifier = $this->getIdentifier($handler);
 
             //Set the configuration
             $identifier->getConfig()->append($config);


### PR DESCRIPTION
When the handler in not a string identifier, i.e. is a string with no period we are setting the $identifier as an array, and then calling $itentifier->getConfig() on that array which gives an error. Removing the else seems to do the trick
(found this to be happening while attempting to use just the koowa library outside of Joomla)