### PR TITLE
Set the database name on KDatabaseAdapterAbstract::__construct

### DIFF
--- a/code/libraries/koowa/libraries/database/adapter/abstract.php
+++ b/code/libraries/koowa/libraries/database/adapter/abstract.php
@@ -105,9 +105,6 @@ abstract class KDatabaseAdapterAbstract extends KObject implements KDatabaseAdap
         // Set the table prefix
         $this->_table_needle = $config->table_needle;
 
-        // Set the database name
-        $this->setDatabase($config->database);
-
         // Mixin the command interface
         $this->mixin('lib:command.mixin', $config);
 

--- a/code/libraries/koowa/libraries/database/adapter/abstract.php
+++ b/code/libraries/koowa/libraries/database/adapter/abstract.php
@@ -106,7 +106,7 @@ abstract class KDatabaseAdapterAbstract extends KObject implements KDatabaseAdap
         $this->_table_needle = $config->table_needle;
 
         // Set the database name
-        $this->_database = $config->database;
+        $this->setDatabase($config->database);
 
         // Mixin the command interface
         $this->mixin('lib:command.mixin', $config);

--- a/code/libraries/koowa/libraries/database/adapter/abstract.php
+++ b/code/libraries/koowa/libraries/database/adapter/abstract.php
@@ -70,13 +70,6 @@ abstract class KDatabaseAdapterAbstract extends KObject implements KDatabaseAdap
      * @var string
      */
     protected $_identifier_quote = '`';
-
-    /**
-     * The connection options
-     *
-     * @var KObjectConfig
-     */
-    protected $_options = null;
     
     /**
      * Character set used for connection

--- a/code/libraries/koowa/libraries/database/adapter/abstract.php
+++ b/code/libraries/koowa/libraries/database/adapter/abstract.php
@@ -112,6 +112,9 @@ abstract class KDatabaseAdapterAbstract extends KObject implements KDatabaseAdap
         // Set the table prefix
         $this->_table_needle = $config->table_needle;
 
+        // Set the database name
+        $this->_database = $config->database;
+
         // Mixin the command interface
         $this->mixin('lib:command.mixin', $config);
 

--- a/code/libraries/koowa/libraries/database/adapter/mysqli.php
+++ b/code/libraries/koowa/libraries/database/adapter/mysqli.php
@@ -140,7 +140,6 @@ class KDatabaseAdapterMysqli extends KDatabaseAdapterAbstract
 
         $this->_connection = $mysqli;
         $this->_connected  = true;
-        $this->_database   = $this->_options->database;
 
         return $this;
     }


### PR DESCRIPTION
$this->_options is not an object so accessing ->database  on line 143 results in an error. There was no code that sets $this->_options. So this line seems to be a leftover code and is not needed. Just set the database name on instantiation and put it at $this->_database.