### PR TITLE
re dont redirect hard by setting headers

### DIFF
--- a/code/libraries/koowa/libraries/controller/model.php
+++ b/code/libraries/koowa/libraries/controller/model.php
@@ -294,7 +294,6 @@ abstract class KControllerModel extends KControllerView implements KControllerMo
                 }
                 else $url->query[$entity->getIdentityKey()] = $entity->getProperty($entity->getIdentityKey());
 
-                $context->response->headers->set('Location', (string) $url);
                 $context->response->setStatus(KHttpResponse::CREATED);
             }
         }


### PR DESCRIPTION
Hey Nooku, 

I'm not sure if this is a breaker change or not, but just to be safe I've branched from the develop branch. 

I've noticed when trying to create a custom redirect based on a new entity being added to the database, that it is impossible to override the redirect that comes from the natural execution of the _actionAdd method. 

I believe this is because the _actionAdd method sets the headers automatically. _actionEdit, _actionDelete all seem just to set the status and then allow the natural controller flow to deal with the redirect. 

By removing the $context->response->headers->set saving a new record results in the same redirects from what I can see, but more importantly it allows after.Add behaviours to be created. 