### PR TITLE
Improved toArray() to handle KModelEntityRow correct.

### DIFF
--- a/code/model/entity/abstract.php
+++ b/code/model/entity/abstract.php
@@ -466,8 +466,10 @@ abstract class KModelEntityAbstract extends KObjectArray implements KModelEntity
 
         foreach ($this->getComputedProperties() as $property)
         {
-            if ($this->{$property} instanceof KModelEntityInterface) {
+            if ($this->{$property} instanceof KModelEntityRowset) {
                 $data[$property] = array_values($this->{$property}->toArray());
+            } elseif ($this->{$property} instanceof KModelEntityRow) {
+                $data[$property] = $this->{$property}->getProperties();
             } else {
                 $data[$property] = $this->{$property};
             }


### PR DESCRIPTION
Improved toArray() to handle KModelEntityRow correct. This scenario happens when doing something like:

public function getPropertyFoo() {
    return $this->getObject('com:foo.model.bars')->id(1)->fetch()->top();
}

So that the JSON output returns: foo: {} (object) instead of foo: [{}] (array).